### PR TITLE
windows integration bugfix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,10 @@ utils.which = function(name, callback) {
 		return callback(null, whichCache[name]);
 	}
 	var cmd = 'which ' + name;
-
+	if (process.platform === 'win32'){
+		cmd = 'where ' + name;
+	}
+	
 	exec(cmd, function(err, stdout) {
 		if (err) {
 			callback(null, whichCache[name] = '');


### PR DESCRIPTION
In the process of using this module, I encountered an error on windows.

events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: spawn /cygdrive/c/sox-14-4-2/sox ENOENT
    at exports._errnoException (util.js:746:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1046:32)
    at child_process.js:1137:20
    at process._tickCallback (node.js:355:11)
I traced down the problem to the fact that the which command did not play well with my cygwin installation. The filepath returned from which is a linux-style path. The path I actually wanted (windows style) is returned by where. So the fix I used was to add the following code at line 45 of lib/utils.js:

if (process.platform === 'win32'){
    cmd = 'where ' + name;
}
This will detect if the current platform is windows, and if so grab the filepath by calling where instead of which.

After adding this fix I had no errors, and was able to use this module successfully.
