### PR TITLE
Spawning with /bin/sh -c  (gott a SIGSEGV when using fade)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -25,7 +25,8 @@ module.exports = function(proto) {
 			var stderr = null;
 			var stderrClosed = false;
 
-			var soxProc = spawn(soxPath, args, options);
+			//var soxProc = spawn(soxPath, args, options);
+            var soxProc = spawn('/bin/sh', ['-c','sox ' + args.join(' ')], options);
 
 			if (soxProc.stderr && options.captureStderr) {
 				soxProc.stderr.setEncoding('utf8');
@@ -114,7 +115,7 @@ module.exports = function(proto) {
 				// The input source is a SoxCommand, so call _getArguments on it
 				if (input.isSubCommand) {
 					var subCommandArgs = input.source._getArguments();
-					source = '|sox ' + subCommandArgs.join(' ');
+					source = subCommandArgs.join(' ') + ' | sox -';
 
 				// The input is a stream, so read from stdin
 				} else if (input.isStream) {
@@ -218,7 +219,7 @@ module.exports = function(proto) {
 			self.emit('prepare', args);
 			self._spawnSox(
 				args, 
-				{shell: true},
+				{},
 				function processCB(soxProc) {
 					self.soxProc = soxProc;
 					self.emit('start', 'sox ' + args.join(' '));

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -26,7 +26,7 @@ module.exports = function(proto) {
 			var stderrClosed = false;
 
 			//var soxProc = spawn(soxPath, args, options);
-            var soxProc = spawn('/bin/sh', ['-c','sox ' + args.join(' ')], options);
+            var soxProc = spawn('/bin/sh', ['-c','"sox ' + args.join(' ') + '"'], options);
 
 			if (soxProc.stderr && options.captureStderr) {
 				soxProc.stderr.setEncoding('utf8');

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -26,8 +26,8 @@ module.exports = function(proto) {
 			var stderrClosed = false;
 
 			//var soxProc = spawn(soxPath, args, options);
-            console.log('/bin/sh -c "sox ' + args.join(' ') + '"');
-            var soxProc = spawn('/bin/sh', ['-c','"sox ' + args.join(' ') + '"'], options);
+            console.log('/bin/sh -c sox ' + args.join(' '));
+            var soxProc = spawn('/bin/sh', ['-c','sox ' + args.join(' ')], options);
 
 			if (soxProc.stderr && options.captureStderr) {
 				soxProc.stderr.setEncoding('utf8');

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -26,6 +26,7 @@ module.exports = function(proto) {
 			var stderrClosed = false;
 
 			//var soxProc = spawn(soxPath, args, options);
+            console.log('/bin/sh -c "sox ' + args.join(' ') + '"');
             var soxProc = spawn('/bin/sh', ['-c','"sox ' + args.join(' ') + '"'], options);
 
 			if (soxProc.stderr && options.captureStderr) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -218,7 +218,7 @@ module.exports = function(proto) {
 			self.emit('prepare', args);
 			self._spawnSox(
 				args, 
-				{},
+				{shell: true},
 				function processCB(soxProc) {
 					self.soxProc = soxProc;
 					self.emit('start', 'sox ' + args.join(' '));


### PR DESCRIPTION
I am not sure why this happened, but I couldn't use the fade effect. The command would get SIGSEGV. When I saw that the command is fine and just `spawn` is not working, I tried changing options and `{shell: true}` did the trick.
Using Node v7.10.1