### PR TITLE
Use hyphen instead of minus sign in regex

### DIFF
--- a/lib/options/effect.js
+++ b/lib/options/effect.js
@@ -5,7 +5,7 @@ var utils = require('../utils');
 
 /* Effect-related methods */
 
-var COMBINE_METHODS = /^(?:concatenate|merge|mix|mix−power|multiply|sequence)$/;
+var COMBINE_METHODS = /^(?:concatenate|merge|mix|mix-power|multiply|sequence)$/;
 
 module.exports = function(proto) {
 
@@ -40,7 +40,7 @@ module.exports = function(proto) {
 	};
 
 	/* Select the input file combining method to be applied to all inputs:
-	* concatenate|merge|mix|mix−power|multiply|sequence
+	* concatenate|merge|mix|mix-power|multiply|sequence
 	*/
 	proto.combine = function(method) {
 		if (COMBINE_METHODS.test(method)) {


### PR DESCRIPTION
The `mix-power` combine method was not working, giving the error: `Error: Invalid combining method mix-power`.

I found that `mix-power` was failing the regex test due to the wrong dash character being used. Character `−` "minus sign" (0x2212) was used instead of the normal `-` "hyphen" (0x2D).